### PR TITLE
defaultPublicPath argument to methodName function

### DIFF
--- a/src/codeBuilders.js
+++ b/src/codeBuilders.js
@@ -98,7 +98,7 @@ exports.buildMethodCode = function (
     `  if (typeof ${methodName} !== "function") {`,
     `    throw new Error("${PLUGIN_NAME}: '${methodName}' is not a function or not available at runtime. See https://github.com/agoldis/webpack-require-from#troubleshooting");`,
     `  }`,
-    `  return ${methodName}();`,
+    `  return ${methodName}("${defaultPublicPath}");`,
     `} catch (e) {`,
     `  if (!${shouldSupressErrors}) {`,
     `    console.error(e);`,


### PR DESCRIPTION
Sometimes it's required to modify the publicPath while taking the defaultPublicPath as a parameter

Usecase: Multiple webpack builds on same page: and defaultPublicPath for each is something like: //mydomain.com/static/<APP_NAME>/ now I need to change it to //myOtherDomain.com/static/<APP_NAME>/

therefore, if I use the plugin like so:

new WebpackRequireFrom({methodName: '__get_public_path__'})

and have __get_public_path__ defined like so:

window.__get_public_path__ = defaultPublicPath => defaultPublicPath.replace('myDomain', 'myOtherDomain')

I would be able to achieve it for all apps